### PR TITLE
apparent bug in handling split settings for low row mode

### DIFF
--- a/ls_settings.ino
+++ b/ls_settings.ino
@@ -1386,13 +1386,13 @@ void handlePerSplitSettingRelease() {
       switch (sensorRow) {
         case 5:
           if (ensureCellBeforeHoldWait(getLowRowCCXColor(Global.currentPerSplit),
-                                       Split[Global.currentPerSplit].expressionForZ == lowRowCCX ? cellOn : cellOff)) {
+                                       Split[Global.currentPerSplit].lowRowMode == lowRowCCX ? cellOn : cellOff)) {
             Split[Global.currentPerSplit].lowRowMode = lowRowCCX;
           }
           break;
         case 4:
           if (ensureCellBeforeHoldWait(getLowRowCCXYZColor(Global.currentPerSplit),
-                                       Split[Global.currentPerSplit].expressionForZ == lowRowCCXYZ ? cellOn : cellOff)) {
+                                       Split[Global.currentPerSplit].lowRowMode == lowRowCCXYZ ? cellOn : cellOff)) {
             Split[Global.currentPerSplit].lowRowMode = lowRowCCXYZ;
           }
           break;


### PR DESCRIPTION
having removed all the char* warnings with another patch (will upload separately if requested), there remained an enum incompatibility warning which exposed a possible bug comparing the state of expressionZ as if it was the state of lowRowMode.