### PR TITLE
put selectSensorCell in a header file so it's visible before its own use

### DIFF
--- a/linnstrument-firmware.ino
+++ b/linnstrument-firmware.ino
@@ -50,7 +50,7 @@ For any questions about this, contact Roger Linn Design at support@rogerlinndesi
 #include "ls_debug.h"
 #include "ls_channelbucket.h"
 #include "ls_midi.h"
-
+#include "ls_sensor.h"
 
 /******************************************** CONSTANTS ******************************************/
 

--- a/ls_sensor.h
+++ b/ls_sensor.h
@@ -1,0 +1,16 @@
+/************************* ls_bytebuffer: LinnStrument ByteBuffer class ***************************
+This work is licensed under the Creative Commons Attribution-ShareAlike 3.0 Unported License.
+To view a copy of this license, visit http://creativecommons.org/licenses/by-sa/3.0/
+or send a letter to Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.
+***************************************************************************************************
+Circular byte buffer that has independent push and pop locations. This allows a fixed memory usage
+for a queue of data, without having to worry about memory allocation.
+
+Once the size of the buffer fills up though, new data will start filling the beginning back up
+again. You need to be careful to select the approriate size of the byte buffer for your use-case
+in order to prevent losing data.
+**************************************************************************************************/
+
+void selectSensorCell(byte col,             // column to be addressed by analog switches
+                      byte row,             // row to be addressed by analog switches
+                      byte switchCode);

--- a/ls_sensor.ino
+++ b/ls_sensor.ino
@@ -6,6 +6,8 @@ or send a letter to Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.
 These functions handle the sensing of touches on the LinnStrument's touch surface.
 **************************************************************************************************/
 
+#include "ls_sensor.h"
+
 // These are the rectified pressure sensititivies for each column
 // CAREFUL, contrary to all the other arrays these are rows first and columns second since it makes it much easier to visualize and edit the
 // actual values in a spreadsheet


### PR DESCRIPTION
Building from rogerlinndesign/linnstrument-firmware using arduino SDK 1.6.9 fails for a couple reasons.

One of them is the use of selectSensorCell in two files before (or absent) any declaration.

I'm mystified how this can work in master, perhaps special whole program optimisation or other compile flags are used.

NOTE: I have no idea about the consequences of the use of the keyword inline in the actual definition of this function if it's not declared with inline.  Some thought required.