### PR TITLE
Transfer16 - runloop micros 4150 -> 3666 us.  Requires Arduino API change 

### DIFF
--- a/arduino_fixes/1.6.4/SPI.cpp
+++ b/arduino_fixes/1.6.4/SPI.cpp
@@ -1,0 +1,313 @@
+/*
+ * Copyright (c) 2010 by Cristian Maglie <c.maglie@arduino.cc>
+ * Copyright (c) 2014 by Paul Stoffregen <paul@pjrc.com> (Transaction API)
+ * SPI Master library for arduino.
+ *
+ * This file is free software; you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License version 2
+ * or the GNU Lesser General Public License version 2.1, both as
+ * published by the Free Software Foundation.
+ */
+
+#include "SPI.h"
+
+SPIClass::SPIClass(Spi *_spi, uint32_t _id, void(*_initCb)(void)) :
+	spi(_spi), id(_id), initCb(_initCb), initialized(false)
+{
+	// Empty
+}
+
+void SPIClass::begin() {
+	init();
+	// NPCS control is left to the user
+
+	// Default speed set to 4Mhz
+	setClockDivider(BOARD_SPI_DEFAULT_SS, 21);
+	setDataMode(BOARD_SPI_DEFAULT_SS, SPI_MODE0);
+	setBitOrder(BOARD_SPI_DEFAULT_SS, MSBFIRST);
+}
+
+void SPIClass::begin(uint8_t _pin) {
+	init();
+
+	uint32_t spiPin = BOARD_PIN_TO_SPI_PIN(_pin);
+	PIO_Configure(
+		g_APinDescription[spiPin].pPort,
+		g_APinDescription[spiPin].ulPinType,
+		g_APinDescription[spiPin].ulPin,
+		g_APinDescription[spiPin].ulPinConfiguration);
+
+	// Default speed set to 4Mhz
+	setClockDivider(_pin, 21);
+	setDataMode(_pin, SPI_MODE0);
+	setBitOrder(_pin, MSBFIRST);
+}
+
+void SPIClass::init() {
+	if (initialized)
+		return;
+	interruptMode = 0;
+	interruptSave = 0;
+	interruptMask[0] = 0;
+	interruptMask[1] = 0;
+	interruptMask[2] = 0;
+	interruptMask[3] = 0;
+	initCb();
+	SPI_Configure(spi, id, SPI_MR_MSTR | SPI_MR_PS | SPI_MR_MODFDIS);
+	SPI_Enable(spi);
+	initialized = true;
+}
+
+#ifndef interruptsStatus
+#define interruptsStatus() __interruptsStatus()
+static inline unsigned char __interruptsStatus(void) __attribute__((always_inline, unused));
+static inline unsigned char __interruptsStatus(void) {
+	unsigned int primask, faultmask;
+	asm volatile ("mrs %0, primask" : "=r" (primask));
+	if (primask) return 0;
+	asm volatile ("mrs %0, faultmask" : "=r" (faultmask));
+	if (faultmask) return 0;
+	return 1;
+}
+#endif
+
+void SPIClass::usingInterrupt(uint8_t interruptNumber)
+{
+	uint8_t irestore;
+
+	irestore = interruptsStatus();
+	noInterrupts();
+	if (interruptMode < 16) {
+		if (interruptNumber > NUM_DIGITAL_PINS) {
+			interruptMode = 16;
+		} else {
+			Pio *pio = g_APinDescription[interruptNumber].pPort;
+			uint32_t mask = g_APinDescription[interruptNumber].ulPin;
+			if (pio == PIOA) {
+				interruptMode |= 1;
+				interruptMask[0] |= mask;
+			} else if (pio == PIOB) {
+				interruptMode |= 2;
+				interruptMask[1] |= mask;
+			} else if (pio == PIOC) {
+				interruptMode |= 4;
+				interruptMask[2] |= mask;
+			} else if (pio == PIOD) {
+				interruptMode |= 8;
+				interruptMask[3] |= mask;
+			} else {
+				interruptMode = 16;
+			}
+		}
+	}
+	if (irestore) interrupts();
+}
+
+void SPIClass::beginTransaction(uint8_t pin, SPISettings settings)
+{
+	uint8_t mode = interruptMode;
+	if (mode > 0) {
+		if (mode < 16) {
+			if (mode & 1) PIOA->PIO_IDR = interruptMask[0];
+			if (mode & 2) PIOB->PIO_IDR = interruptMask[1];
+			if (mode & 4) PIOC->PIO_IDR = interruptMask[2];
+			if (mode & 8) PIOD->PIO_IDR = interruptMask[3];
+		} else {
+			interruptSave = interruptsStatus();
+			noInterrupts();
+		}
+	}
+	uint32_t ch = BOARD_PIN_TO_SPI_CHANNEL(pin);
+	bitOrder[ch] = settings.border;
+	SPI_ConfigureNPCS(spi, ch, settings.config);
+	//setBitOrder(pin, settings.border);
+	//setDataMode(pin, settings.datamode);
+	//setClockDivider(pin, settings.clockdiv);
+}
+
+void SPIClass::endTransaction(void)
+{
+	uint8_t mode = interruptMode;
+	if (mode > 0) {
+		if (mode < 16) {
+			if (mode & 1) PIOA->PIO_IER = interruptMask[0];
+			if (mode & 2) PIOB->PIO_IER = interruptMask[1];
+			if (mode & 4) PIOC->PIO_IER = interruptMask[2];
+			if (mode & 8) PIOD->PIO_IER = interruptMask[3];
+		} else {
+			if (interruptSave) interrupts();
+		}
+	}
+}
+
+void SPIClass::end(uint8_t _pin) {
+	uint32_t spiPin = BOARD_PIN_TO_SPI_PIN(_pin);
+	// Setting the pin as INPUT will disconnect it from SPI peripheral
+	pinMode(spiPin, INPUT);
+}
+
+void SPIClass::end() {
+	SPI_Disable(spi);
+	initialized = false;
+}
+
+void SPIClass::setBitOrder(uint8_t _pin, BitOrder _bitOrder) {
+	uint32_t ch = BOARD_PIN_TO_SPI_CHANNEL(_pin);
+	bitOrder[ch] = _bitOrder;
+}
+
+void SPIClass::setDataMode(uint8_t _pin, uint8_t _mode) {
+	uint32_t ch = BOARD_PIN_TO_SPI_CHANNEL(_pin);
+	mode[ch] = _mode | SPI_CSR_CSAAT;
+	// SPI_CSR_DLYBCT(1) keeps CS enabled for 32 MCLK after a completed
+	// transfer. Some device needs that for working properly.
+	SPI_ConfigureNPCS(spi, ch, mode[ch] | SPI_CSR_SCBR(divider[ch]) | dataWidth[ch] | SPI_CSR_DLYBCT(1));
+}
+
+void SPIClass::setDataWidth(uint8_t _pin, uint8_t _dataWidth) {
+	uint32_t ch = BOARD_PIN_TO_SPI_CHANNEL(_pin);
+	dataWidth[ch] = _dataWidth;
+	// SPI_CSR_DLYBCT(1) keeps CS enabled for 32 MCLK after a completed
+	// transfer. Some device needs that for working properly.
+	SPI_ConfigureNPCS(spi, ch, mode[ch] | SPI_CSR_SCBR(divider[ch]) | dataWidth[ch] | SPI_CSR_DLYBCT(1));
+}
+
+void SPIClass::setClockDivider(uint8_t _pin, uint8_t _divider) {
+	uint32_t ch = BOARD_PIN_TO_SPI_CHANNEL(_pin);
+	divider[ch] = _divider;
+	// SPI_CSR_DLYBCT(1) keeps CS enabled for 32 MCLK after a completed
+	// transfer. Some device needs that for working properly.
+	SPI_ConfigureNPCS(spi, ch, mode[ch] | SPI_CSR_SCBR(divider[ch]) | dataWidth[ch] | SPI_CSR_DLYBCT(1));
+}
+
+// only works if data mode is set correctly to SPI_CSR_BITS_16_BIT
+uint16_t SPIClass::transfer16(byte _pin, uint16_t _data, SPITransferMode _mode) {
+	uint32_t ch = BOARD_PIN_TO_SPI_CHANNEL(_pin);
+	// Reverse bit order
+	if (bitOrder[ch] == LSBFIRST)
+		_data = __REV(__RBIT(_data));
+	uint32_t d = _data | SPI_PCS(ch);
+	if (_mode == SPI_LAST)
+		d |= SPI_TDR_LASTXFER;
+
+	// SPI_Write(spi, _channel, _data);
+	while ((spi->SPI_SR & SPI_SR_TDRE) == 0)
+		;
+	spi->SPI_TDR = d;
+
+	// return SPI_Read(spi);
+	while ((spi->SPI_SR & SPI_SR_RDRF) == 0)
+		;
+	d = spi->SPI_RDR;
+	// Reverse bit order
+	if (bitOrder[ch] == LSBFIRST)
+		d = __REV(__RBIT(d));
+	return d & 0xFFFF;
+}
+
+byte SPIClass::transfer(byte _pin, uint8_t _data, SPITransferMode _mode) {
+	uint32_t ch = BOARD_PIN_TO_SPI_CHANNEL(_pin);
+	// Reverse bit order
+	if (bitOrder[ch] == LSBFIRST)
+		_data = __REV(__RBIT(_data));
+	uint32_t d = _data | SPI_PCS(ch);
+	if (_mode == SPI_LAST)
+		d |= SPI_TDR_LASTXFER;
+
+	// SPI_Write(spi, _channel, _data);
+	while ((spi->SPI_SR & SPI_SR_TDRE) == 0)
+		;
+	spi->SPI_TDR = d;
+
+	// return SPI_Read(spi);
+	while ((spi->SPI_SR & SPI_SR_RDRF) == 0)
+		;
+	d = spi->SPI_RDR;
+	// Reverse bit order
+	if (bitOrder[ch] == LSBFIRST)
+		d = __REV(__RBIT(d));
+	return d & 0xFF;
+}
+
+void SPIClass::transfer(byte _pin, void *_buf, size_t _count, SPITransferMode _mode) {
+	if (_count == 0)
+		return;
+
+	uint8_t *buffer = (uint8_t *)_buf;
+	if (_count == 1) {
+		*buffer = transfer(_pin, *buffer, _mode);
+		return;
+	}
+
+	uint32_t ch = BOARD_PIN_TO_SPI_CHANNEL(_pin);
+	bool reverse = (bitOrder[ch] == LSBFIRST);
+
+	// Send the first byte
+	uint32_t d = *buffer;
+	if (reverse)
+		d = __REV(__RBIT(d));
+	while ((spi->SPI_SR & SPI_SR_TDRE) == 0)
+		;
+	spi->SPI_TDR = d | SPI_PCS(ch);
+
+	while (_count > 1) {
+		// Prepare next byte
+		d = *(buffer+1);
+		if (reverse)
+			d = __REV(__RBIT(d));
+		if (_count == 2 && _mode == SPI_LAST)
+			d |= SPI_TDR_LASTXFER;
+
+		// Read transferred byte and send next one straight away
+		while ((spi->SPI_SR & SPI_SR_RDRF) == 0)
+			;
+		uint8_t r = spi->SPI_RDR;
+		spi->SPI_TDR = d | SPI_PCS(ch);
+
+		// Save read byte
+		if (reverse)
+			r = __REV(__RBIT(r));
+		*buffer = r;
+		buffer++;
+		_count--;
+	}
+
+	// Receive the last transferred byte
+	while ((spi->SPI_SR & SPI_SR_RDRF) == 0)
+		;
+	uint8_t r = spi->SPI_RDR;
+	if (reverse)
+		r = __REV(__RBIT(r));
+	*buffer = r;
+}
+
+void SPIClass::attachInterrupt(void) {
+	// Should be enableInterrupt()
+}
+
+void SPIClass::detachInterrupt(void) {
+	// Should be disableInterrupt()
+}
+
+#if SPI_INTERFACES_COUNT > 0
+static void SPI_0_Init(void) {
+	PIO_Configure(
+			g_APinDescription[PIN_SPI_MOSI].pPort,
+			g_APinDescription[PIN_SPI_MOSI].ulPinType,
+			g_APinDescription[PIN_SPI_MOSI].ulPin,
+			g_APinDescription[PIN_SPI_MOSI].ulPinConfiguration);
+	PIO_Configure(
+			g_APinDescription[PIN_SPI_MISO].pPort,
+			g_APinDescription[PIN_SPI_MISO].ulPinType,
+			g_APinDescription[PIN_SPI_MISO].ulPin,
+			g_APinDescription[PIN_SPI_MISO].ulPinConfiguration);
+	PIO_Configure(
+			g_APinDescription[PIN_SPI_SCK].pPort,
+			g_APinDescription[PIN_SPI_SCK].ulPinType,
+			g_APinDescription[PIN_SPI_SCK].ulPin,
+			g_APinDescription[PIN_SPI_SCK].ulPinConfiguration);
+}
+
+SPIClass SPI(SPI_INTERFACE, SPI_INTERFACE_ID, SPI_0_Init);
+#endif
+

--- a/arduino_fixes/1.6.4/SPI.cpp.orig
+++ b/arduino_fixes/1.6.4/SPI.cpp.orig
@@ -1,0 +1,280 @@
+/*
+ * Copyright (c) 2010 by Cristian Maglie <c.maglie@arduino.cc>
+ * Copyright (c) 2014 by Paul Stoffregen <paul@pjrc.com> (Transaction API)
+ * SPI Master library for arduino.
+ *
+ * This file is free software; you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License version 2
+ * or the GNU Lesser General Public License version 2.1, both as
+ * published by the Free Software Foundation.
+ */
+
+#include "SPI.h"
+
+SPIClass::SPIClass(Spi *_spi, uint32_t _id, void(*_initCb)(void)) :
+	spi(_spi), id(_id), initCb(_initCb), initialized(false)
+{
+	// Empty
+}
+
+void SPIClass::begin() {
+	init();
+	// NPCS control is left to the user
+
+	// Default speed set to 4Mhz
+	setClockDivider(BOARD_SPI_DEFAULT_SS, 21);
+	setDataMode(BOARD_SPI_DEFAULT_SS, SPI_MODE0);
+	setBitOrder(BOARD_SPI_DEFAULT_SS, MSBFIRST);
+}
+
+void SPIClass::begin(uint8_t _pin) {
+	init();
+
+	uint32_t spiPin = BOARD_PIN_TO_SPI_PIN(_pin);
+	PIO_Configure(
+		g_APinDescription[spiPin].pPort,
+		g_APinDescription[spiPin].ulPinType,
+		g_APinDescription[spiPin].ulPin,
+		g_APinDescription[spiPin].ulPinConfiguration);
+
+	// Default speed set to 4Mhz
+	setClockDivider(_pin, 21);
+	setDataMode(_pin, SPI_MODE0);
+	setBitOrder(_pin, MSBFIRST);
+}
+
+void SPIClass::init() {
+	if (initialized)
+		return;
+	interruptMode = 0;
+	interruptSave = 0;
+	interruptMask[0] = 0;
+	interruptMask[1] = 0;
+	interruptMask[2] = 0;
+	interruptMask[3] = 0;
+	initCb();
+	SPI_Configure(spi, id, SPI_MR_MSTR | SPI_MR_PS | SPI_MR_MODFDIS);
+	SPI_Enable(spi);
+	initialized = true;
+}
+
+#ifndef interruptsStatus
+#define interruptsStatus() __interruptsStatus()
+static inline unsigned char __interruptsStatus(void) __attribute__((always_inline, unused));
+static inline unsigned char __interruptsStatus(void) {
+	unsigned int primask, faultmask;
+	asm volatile ("mrs %0, primask" : "=r" (primask));
+	if (primask) return 0;
+	asm volatile ("mrs %0, faultmask" : "=r" (faultmask));
+	if (faultmask) return 0;
+	return 1;
+}
+#endif
+
+void SPIClass::usingInterrupt(uint8_t interruptNumber)
+{
+	uint8_t irestore;
+
+	irestore = interruptsStatus();
+	noInterrupts();
+	if (interruptMode < 16) {
+		if (interruptNumber > NUM_DIGITAL_PINS) {
+			interruptMode = 16;
+		} else {
+			Pio *pio = g_APinDescription[interruptNumber].pPort;
+			uint32_t mask = g_APinDescription[interruptNumber].ulPin;
+			if (pio == PIOA) {
+				interruptMode |= 1;
+				interruptMask[0] |= mask;
+			} else if (pio == PIOB) {
+				interruptMode |= 2;
+				interruptMask[1] |= mask;
+			} else if (pio == PIOC) {
+				interruptMode |= 4;
+				interruptMask[2] |= mask;
+			} else if (pio == PIOD) {
+				interruptMode |= 8;
+				interruptMask[3] |= mask;
+			} else {
+				interruptMode = 16;
+			}
+		}
+	}
+	if (irestore) interrupts();
+}
+
+void SPIClass::beginTransaction(uint8_t pin, SPISettings settings)
+{
+	uint8_t mode = interruptMode;
+	if (mode > 0) {
+		if (mode < 16) {
+			if (mode & 1) PIOA->PIO_IDR = interruptMask[0];
+			if (mode & 2) PIOB->PIO_IDR = interruptMask[1];
+			if (mode & 4) PIOC->PIO_IDR = interruptMask[2];
+			if (mode & 8) PIOD->PIO_IDR = interruptMask[3];
+		} else {
+			interruptSave = interruptsStatus();
+			noInterrupts();
+		}
+	}
+	uint32_t ch = BOARD_PIN_TO_SPI_CHANNEL(pin);
+	bitOrder[ch] = settings.border;
+	SPI_ConfigureNPCS(spi, ch, settings.config);
+	//setBitOrder(pin, settings.border);
+	//setDataMode(pin, settings.datamode);
+	//setClockDivider(pin, settings.clockdiv);
+}
+
+void SPIClass::endTransaction(void)
+{
+	uint8_t mode = interruptMode;
+	if (mode > 0) {
+		if (mode < 16) {
+			if (mode & 1) PIOA->PIO_IER = interruptMask[0];
+			if (mode & 2) PIOB->PIO_IER = interruptMask[1];
+			if (mode & 4) PIOC->PIO_IER = interruptMask[2];
+			if (mode & 8) PIOD->PIO_IER = interruptMask[3];
+		} else {
+			if (interruptSave) interrupts();
+		}
+	}
+}
+
+void SPIClass::end(uint8_t _pin) {
+	uint32_t spiPin = BOARD_PIN_TO_SPI_PIN(_pin);
+	// Setting the pin as INPUT will disconnect it from SPI peripheral
+	pinMode(spiPin, INPUT);
+}
+
+void SPIClass::end() {
+	SPI_Disable(spi);
+	initialized = false;
+}
+
+void SPIClass::setBitOrder(uint8_t _pin, BitOrder _bitOrder) {
+	uint32_t ch = BOARD_PIN_TO_SPI_CHANNEL(_pin);
+	bitOrder[ch] = _bitOrder;
+}
+
+void SPIClass::setDataMode(uint8_t _pin, uint8_t _mode) {
+	uint32_t ch = BOARD_PIN_TO_SPI_CHANNEL(_pin);
+	mode[ch] = _mode | SPI_CSR_CSAAT;
+	// SPI_CSR_DLYBCT(1) keeps CS enabled for 32 MCLK after a completed
+	// transfer. Some device needs that for working properly.
+	SPI_ConfigureNPCS(spi, ch, mode[ch] | SPI_CSR_SCBR(divider[ch]) | SPI_CSR_DLYBCT(1));
+}
+
+void SPIClass::setClockDivider(uint8_t _pin, uint8_t _divider) {
+	uint32_t ch = BOARD_PIN_TO_SPI_CHANNEL(_pin);
+	divider[ch] = _divider;
+	// SPI_CSR_DLYBCT(1) keeps CS enabled for 32 MCLK after a completed
+	// transfer. Some device needs that for working properly.
+	SPI_ConfigureNPCS(spi, ch, mode[ch] | SPI_CSR_SCBR(divider[ch]) | SPI_CSR_DLYBCT(1));
+}
+
+byte SPIClass::transfer(byte _pin, uint8_t _data, SPITransferMode _mode) {
+	uint32_t ch = BOARD_PIN_TO_SPI_CHANNEL(_pin);
+	// Reverse bit order
+	if (bitOrder[ch] == LSBFIRST)
+		_data = __REV(__RBIT(_data));
+	uint32_t d = _data | SPI_PCS(ch);
+	if (_mode == SPI_LAST)
+		d |= SPI_TDR_LASTXFER;
+
+	// SPI_Write(spi, _channel, _data);
+	while ((spi->SPI_SR & SPI_SR_TDRE) == 0)
+		;
+	spi->SPI_TDR = d;
+
+	// return SPI_Read(spi);
+	while ((spi->SPI_SR & SPI_SR_RDRF) == 0)
+		;
+	d = spi->SPI_RDR;
+	// Reverse bit order
+	if (bitOrder[ch] == LSBFIRST)
+		d = __REV(__RBIT(d));
+	return d & 0xFF;
+}
+
+void SPIClass::transfer(byte _pin, void *_buf, size_t _count, SPITransferMode _mode) {
+	if (_count == 0)
+		return;
+
+	uint8_t *buffer = (uint8_t *)_buf;
+	if (_count == 1) {
+		*buffer = transfer(_pin, *buffer, _mode);
+		return;
+	}
+
+	uint32_t ch = BOARD_PIN_TO_SPI_CHANNEL(_pin);
+	bool reverse = (bitOrder[ch] == LSBFIRST);
+
+	// Send the first byte
+	uint32_t d = *buffer;
+	if (reverse)
+		d = __REV(__RBIT(d));
+	while ((spi->SPI_SR & SPI_SR_TDRE) == 0)
+		;
+	spi->SPI_TDR = d | SPI_PCS(ch);
+
+	while (_count > 1) {
+		// Prepare next byte
+		d = *(buffer+1);
+		if (reverse)
+			d = __REV(__RBIT(d));
+		if (_count == 2 && _mode == SPI_LAST)
+			d |= SPI_TDR_LASTXFER;
+
+		// Read transferred byte and send next one straight away
+		while ((spi->SPI_SR & SPI_SR_RDRF) == 0)
+			;
+		uint8_t r = spi->SPI_RDR;
+		spi->SPI_TDR = d | SPI_PCS(ch);
+
+		// Save read byte
+		if (reverse)
+			r = __REV(__RBIT(r));
+		*buffer = r;
+		buffer++;
+		_count--;
+	}
+
+	// Receive the last transferred byte
+	while ((spi->SPI_SR & SPI_SR_RDRF) == 0)
+		;
+	uint8_t r = spi->SPI_RDR;
+	if (reverse)
+		r = __REV(__RBIT(r));
+	*buffer = r;
+}
+
+void SPIClass::attachInterrupt(void) {
+	// Should be enableInterrupt()
+}
+
+void SPIClass::detachInterrupt(void) {
+	// Should be disableInterrupt()
+}
+
+#if SPI_INTERFACES_COUNT > 0
+static void SPI_0_Init(void) {
+	PIO_Configure(
+			g_APinDescription[PIN_SPI_MOSI].pPort,
+			g_APinDescription[PIN_SPI_MOSI].ulPinType,
+			g_APinDescription[PIN_SPI_MOSI].ulPin,
+			g_APinDescription[PIN_SPI_MOSI].ulPinConfiguration);
+	PIO_Configure(
+			g_APinDescription[PIN_SPI_MISO].pPort,
+			g_APinDescription[PIN_SPI_MISO].ulPinType,
+			g_APinDescription[PIN_SPI_MISO].ulPin,
+			g_APinDescription[PIN_SPI_MISO].ulPinConfiguration);
+	PIO_Configure(
+			g_APinDescription[PIN_SPI_SCK].pPort,
+			g_APinDescription[PIN_SPI_SCK].ulPinType,
+			g_APinDescription[PIN_SPI_SCK].ulPin,
+			g_APinDescription[PIN_SPI_SCK].ulPinConfiguration);
+}
+
+SPIClass SPI(SPI_INTERFACE, SPI_INTERFACE_ID, SPI_0_Init);
+#endif
+

--- a/arduino_fixes/1.6.4/SPI.h
+++ b/arduino_fixes/1.6.4/SPI.h
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2010 by Cristian Maglie <c.maglie@arduino.cc>
+ * Copyright (c) 2014 by Paul Stoffregen <paul@pjrc.com> (Transaction API)
+ * SPI Master library for arduino.
+ *
+ * This file is free software; you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License version 2
+ * or the GNU Lesser General Public License version 2.1, both as
+ * published by the Free Software Foundation.
+ */
+
+#ifndef _SPI_H_INCLUDED
+#define _SPI_H_INCLUDED
+
+#include "variant.h"
+#include <stdio.h>
+
+// SPI_HAS_TRANSACTION means SPI has
+//   - beginTransaction()
+//   - endTransaction()
+//   - usingInterrupt()
+//   - SPISetting(clock, bitOrder, dataMode)
+#define SPI_HAS_TRANSACTION 1
+
+// SPI_HAS_EXTENDED_CS_PIN_HANDLING means SPI has automatic 
+// CS pin handling and provides the following methods:
+//   - begin(pin)
+//   - end(pin)
+//   - setBitOrder(pin, bitorder)
+//   - setDataMode(pin, datamode)
+//   - setClockDivider(pin, clockdiv)
+//   - transfer(pin, data, SPI_LAST/SPI_CONTINUE)
+//   - beginTransaction(pin, SPISettings settings) (if transactions are available)
+#define SPI_HAS_EXTENDED_CS_PIN_HANDLING 1
+
+#define SPI_MODE0 0x02
+#define SPI_MODE1 0x00
+#define SPI_MODE2 0x03
+#define SPI_MODE3 0x01
+
+enum SPITransferMode {
+	SPI_CONTINUE,
+	SPI_LAST
+};
+
+class SPISettings {
+public:
+	SPISettings(uint32_t clock, BitOrder bitOrder, uint8_t dataMode) {
+		if (__builtin_constant_p(clock)) {
+			init_AlwaysInline(clock, bitOrder, dataMode);
+		} else {
+			init_MightInline(clock, bitOrder, dataMode);
+		}
+	}
+	SPISettings() { init_AlwaysInline(4000000, MSBFIRST, SPI_MODE0); }
+private:
+	void init_MightInline(uint32_t clock, BitOrder bitOrder, uint8_t dataMode) {
+		init_AlwaysInline(clock, bitOrder, dataMode);
+	}
+	void init_AlwaysInline(uint32_t clock, BitOrder bitOrder, uint8_t dataMode) __attribute__((__always_inline__)) {
+		border = bitOrder;
+		uint8_t div;
+		if (clock < (F_CPU / 255)) {
+			div = 255;
+		} else if (clock >= (F_CPU / 2)) {
+			div = 2;
+		} else {
+			div = (F_CPU / (clock + 1)) + 1;
+		}
+		config = (dataMode & 3) | SPI_CSR_CSAAT | SPI_CSR_SCBR(div) | SPI_CSR_DLYBCT(1);
+	}
+	uint32_t config;
+	BitOrder border;
+	friend class SPIClass;
+};
+
+
+
+class SPIClass {
+  public:
+	SPIClass(Spi *_spi, uint32_t _id, void(*_initCb)(void));
+
+	// Transfer functions
+	byte transfer(byte _pin, uint8_t _data, SPITransferMode _mode = SPI_LAST);
+	void transfer(byte _pin, void *_buf, size_t _count, SPITransferMode _mode = SPI_LAST);
+        uint16_t transfer16(byte _pin, uint16_t _data, SPITransferMode _mode = SPI_LAST);
+	// Transfer functions on default pin BOARD_SPI_DEFAULT_SS
+	byte transfer(uint8_t _data, SPITransferMode _mode = SPI_LAST) { return transfer(BOARD_SPI_DEFAULT_SS, _data, _mode); }
+	void transfer(void *_buf, size_t _count, SPITransferMode _mode = SPI_LAST) { transfer(BOARD_SPI_DEFAULT_SS, _buf, _count, _mode); }
+
+	// Transaction Functions
+	void usingInterrupt(uint8_t interruptNumber);
+	void beginTransaction(SPISettings settings) { beginTransaction(BOARD_SPI_DEFAULT_SS, settings); }
+	void beginTransaction(uint8_t pin, SPISettings settings);
+	void endTransaction(void);
+
+	// SPI Configuration methods
+	void attachInterrupt(void);
+	void detachInterrupt(void);
+
+	void begin(void);
+	void end(void);
+
+	// Attach/Detach pin to/from SPI controller
+	void begin(uint8_t _pin);
+	void end(uint8_t _pin);
+
+	// These methods sets a parameter on a single pin
+	void setBitOrder(uint8_t _pin, BitOrder);
+	void setDataMode(uint8_t _pin, uint8_t);
+	void setClockDivider(uint8_t _pin, uint8_t);
+        void setDataWidth(uint8_t _pin, uint8_t _dataWidth);
+
+	// These methods sets the same parameters but on default pin BOARD_SPI_DEFAULT_SS
+	void setBitOrder(BitOrder _order) { setBitOrder(BOARD_SPI_DEFAULT_SS, _order); };
+	void setDataMode(uint8_t _mode) { setDataMode(BOARD_SPI_DEFAULT_SS, _mode); };
+	void setClockDivider(uint8_t _div) { setClockDivider(BOARD_SPI_DEFAULT_SS, _div); };
+
+  private:
+	void init();
+
+	Spi *spi;
+	uint32_t id;
+	BitOrder bitOrder[SPI_CHANNELS_NUM];
+	uint32_t divider[SPI_CHANNELS_NUM];
+	uint32_t mode[SPI_CHANNELS_NUM];
+        uint32_t dataWidth[SPI_CHANNELS_NUM];
+	void (*initCb)(void);
+	bool initialized;
+	uint8_t interruptMode;    // 0=none, 1-15=mask, 16=global
+	uint8_t interruptSave;    // temp storage, to restore state
+	uint32_t interruptMask[4];
+};
+
+#if SPI_INTERFACES_COUNT > 0
+extern SPIClass SPI;
+#endif
+
+// For compatibility with sketches designed for AVR @ 16 MHz
+// New programs should use SPI.beginTransaction to set the SPI clock
+#define SPI_CLOCK_DIV2	 11
+#define SPI_CLOCK_DIV4	 21
+#define SPI_CLOCK_DIV8	 42
+#define SPI_CLOCK_DIV16	 84
+#define SPI_CLOCK_DIV32	 168
+#define SPI_CLOCK_DIV64	 255
+#define SPI_CLOCK_DIV128 255
+
+#endif

--- a/arduino_fixes/1.6.4/SPI.h.orig
+++ b/arduino_fixes/1.6.4/SPI.h.orig
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2010 by Cristian Maglie <c.maglie@arduino.cc>
+ * Copyright (c) 2014 by Paul Stoffregen <paul@pjrc.com> (Transaction API)
+ * SPI Master library for arduino.
+ *
+ * This file is free software; you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License version 2
+ * or the GNU Lesser General Public License version 2.1, both as
+ * published by the Free Software Foundation.
+ */
+
+#ifndef _SPI_H_INCLUDED
+#define _SPI_H_INCLUDED
+
+#include "variant.h"
+#include <stdio.h>
+
+// SPI_HAS_TRANSACTION means SPI has
+//   - beginTransaction()
+//   - endTransaction()
+//   - usingInterrupt()
+//   - SPISetting(clock, bitOrder, dataMode)
+#define SPI_HAS_TRANSACTION 1
+
+// SPI_HAS_EXTENDED_CS_PIN_HANDLING means SPI has automatic 
+// CS pin handling and provides the following methods:
+//   - begin(pin)
+//   - end(pin)
+//   - setBitOrder(pin, bitorder)
+//   - setDataMode(pin, datamode)
+//   - setClockDivider(pin, clockdiv)
+//   - transfer(pin, data, SPI_LAST/SPI_CONTINUE)
+//   - beginTransaction(pin, SPISettings settings) (if transactions are available)
+#define SPI_HAS_EXTENDED_CS_PIN_HANDLING 1
+
+#define SPI_MODE0 0x02
+#define SPI_MODE1 0x00
+#define SPI_MODE2 0x03
+#define SPI_MODE3 0x01
+
+enum SPITransferMode {
+	SPI_CONTINUE,
+	SPI_LAST
+};
+
+class SPISettings {
+public:
+	SPISettings(uint32_t clock, BitOrder bitOrder, uint8_t dataMode) {
+		if (__builtin_constant_p(clock)) {
+			init_AlwaysInline(clock, bitOrder, dataMode);
+		} else {
+			init_MightInline(clock, bitOrder, dataMode);
+		}
+	}
+	SPISettings() { init_AlwaysInline(4000000, MSBFIRST, SPI_MODE0); }
+private:
+	void init_MightInline(uint32_t clock, BitOrder bitOrder, uint8_t dataMode) {
+		init_AlwaysInline(clock, bitOrder, dataMode);
+	}
+	void init_AlwaysInline(uint32_t clock, BitOrder bitOrder, uint8_t dataMode) __attribute__((__always_inline__)) {
+		border = bitOrder;
+		uint8_t div;
+		if (clock < (F_CPU / 255)) {
+			div = 255;
+		} else if (clock >= (F_CPU / 2)) {
+			div = 2;
+		} else {
+			div = (F_CPU / (clock + 1)) + 1;
+		}
+		config = (dataMode & 3) | SPI_CSR_CSAAT | SPI_CSR_SCBR(div) | SPI_CSR_DLYBCT(1);
+	}
+	uint32_t config;
+	BitOrder border;
+	friend class SPIClass;
+};
+
+
+
+class SPIClass {
+  public:
+	SPIClass(Spi *_spi, uint32_t _id, void(*_initCb)(void));
+
+	// Transfer functions
+	byte transfer(byte _pin, uint8_t _data, SPITransferMode _mode = SPI_LAST);
+	void transfer(byte _pin, void *_buf, size_t _count, SPITransferMode _mode = SPI_LAST);
+	// Transfer functions on default pin BOARD_SPI_DEFAULT_SS
+	byte transfer(uint8_t _data, SPITransferMode _mode = SPI_LAST) { return transfer(BOARD_SPI_DEFAULT_SS, _data, _mode); }
+	void transfer(void *_buf, size_t _count, SPITransferMode _mode = SPI_LAST) { transfer(BOARD_SPI_DEFAULT_SS, _buf, _count, _mode); }
+
+	// Transaction Functions
+	void usingInterrupt(uint8_t interruptNumber);
+	void beginTransaction(SPISettings settings) { beginTransaction(BOARD_SPI_DEFAULT_SS, settings); }
+	void beginTransaction(uint8_t pin, SPISettings settings);
+	void endTransaction(void);
+
+	// SPI Configuration methods
+	void attachInterrupt(void);
+	void detachInterrupt(void);
+
+	void begin(void);
+	void end(void);
+
+	// Attach/Detach pin to/from SPI controller
+	void begin(uint8_t _pin);
+	void end(uint8_t _pin);
+
+	// These methods sets a parameter on a single pin
+	void setBitOrder(uint8_t _pin, BitOrder);
+	void setDataMode(uint8_t _pin, uint8_t);
+	void setClockDivider(uint8_t _pin, uint8_t);
+
+	// These methods sets the same parameters but on default pin BOARD_SPI_DEFAULT_SS
+	void setBitOrder(BitOrder _order) { setBitOrder(BOARD_SPI_DEFAULT_SS, _order); };
+	void setDataMode(uint8_t _mode) { setDataMode(BOARD_SPI_DEFAULT_SS, _mode); };
+	void setClockDivider(uint8_t _div) { setClockDivider(BOARD_SPI_DEFAULT_SS, _div); };
+
+  private:
+	void init();
+
+	Spi *spi;
+	uint32_t id;
+	BitOrder bitOrder[SPI_CHANNELS_NUM];
+	uint32_t divider[SPI_CHANNELS_NUM];
+	uint32_t mode[SPI_CHANNELS_NUM];
+	void (*initCb)(void);
+	bool initialized;
+	uint8_t interruptMode;    // 0=none, 1-15=mask, 16=global
+	uint8_t interruptSave;    // temp storage, to restore state
+	uint32_t interruptMask[4];
+};
+
+#if SPI_INTERFACES_COUNT > 0
+extern SPIClass SPI;
+#endif
+
+// For compatibility with sketches designed for AVR @ 16 MHz
+// New programs should use SPI.beginTransaction to set the SPI clock
+#define SPI_CLOCK_DIV2	 11
+#define SPI_CLOCK_DIV4	 21
+#define SPI_CLOCK_DIV8	 42
+#define SPI_CLOCK_DIV16	 84
+#define SPI_CLOCK_DIV32	 168
+#define SPI_CLOCK_DIV64	 255
+#define SPI_CLOCK_DIV128 255
+
+#endif

--- a/linnstrument-firmware.ino
+++ b/linnstrument-firmware.ino
@@ -947,6 +947,7 @@ void setup() {
   /*!!*/  // initialize the SPI port for setting one column of LEDs
   /*!!*/  SPI.begin(SPI_LEDS);
   /*!!*/  SPI.setDataMode(SPI_LEDS, SPI_MODE0);
+          SPI.setDataWidth(SPI_LEDS, SPI_CSR_BITS_16_BIT);
   /*!!*/  SPI.setClockDivider(SPI_LEDS, 4);                   // max clock is about 20 mHz. 4 = 21 mHz. Transferring all 4 bytes takes 1.9 uS.
   /*!!*/
   /*!!*/  // initialize the SPI port for setting analog switches in touch sensor

--- a/linnstrument-firmware.ino
+++ b/linnstrument-firmware.ino
@@ -955,6 +955,8 @@ void setup() {
   /*!!*/  SPI.setDataMode(SPI_SENSOR, SPI_MODE0);
   /*!!*/  SPI.setClockDivider(SPI_SENSOR, 4);                 // set clock speed to 84/4 = 21 mHz. Max clock is 25mHz @ 4.5v
   /*!!*/  selectSensorCell(0, 0, READ_Z);                     // set it analog switches to read column 0, row 0 and to read pressure
+            SPI.setDataWidth(SPI_SENSOR, SPI_CSR_BITS_16_BIT);
+
   /*!!*/
   /*!!*/  // initialize the SPI input port for reading the TI ADS7883 ADC
   /*!!*/  SPI.begin(SPI_ADC);

--- a/linnstrument-firmware.ino
+++ b/linnstrument-firmware.ino
@@ -961,6 +961,8 @@ void setup() {
   /*!!*/  SPI.setDataMode(SPI_ADC, SPI_MODE0);
   /*!!*/  SPI.setClockDivider(SPI_ADC, 4);                    // set speed to 84/4 = 21 mHz. Max clock for ADC is 32 mHz @ 2.7-4.5v, 48mHz @ 4.5-5.5v
   /*!!*/
+          SPI.setDataWidth(SPI_ADC, SPI_CSR_BITS_16_BIT);
+
   /*!!*/  // Initialize the output enable line for the 2 LED display chips
   /*!!*/  pinMode(37, OUTPUT);
   /*!!*/  digitalWrite(37, HIGH);

--- a/ls_leds.ino
+++ b/ls_leds.ino
@@ -267,9 +267,8 @@ void refreshLedColumn(unsigned long now) {
   ledColShifted = actualCol << 2;
   if ((actualCol & 16) == 0) ledColShifted |= B10000000;          // if column address 4 is 0, set bit 7
 
-  SPI.transfer(SPI_LEDS, ~ledColShifted, SPI_CONTINUE);           // send column address
-  SPI.transfer(SPI_LEDS, blue, SPI_CONTINUE);                     // send blue byte
-  SPI.transfer(SPI_LEDS, green, SPI_CONTINUE);                    // send green byte
-  SPI.transfer(SPI_LEDS, red);                                    // send red byte
+  SPI.transfer16(SPI_LEDS, ((((uint16_t)~ledColShifted) <<8) | blue), SPI_CONTINUE);           // send column address
+  SPI.transfer16(SPI_LEDS, (((uint16_t)green) << 8) | red);                    // send green byte
+  
   digitalWrite(37, LOW);                                          // enable the outputs of the LED driver chips
 }

--- a/ls_sensor.ino
+++ b/ls_sensor.ino
@@ -187,6 +187,6 @@ inline void selectSensorCell(byte col, byte row, byte switchCode) {
     break;
   }
 
-  SPI.transfer(SPI_SENSOR, lsb, SPI_CONTINUE);    // to daisy-chained 595 (LSB)
-  SPI.transfer(SPI_SENSOR, msb);                  // to first 595 at MOSI (MSB, for both sensor columns and LED columns)
+  SPI.transfer16(SPI_SENSOR, (short)lsb<<8 | msb);    // to daisy-chained 595 (LSB)
+                                                      // to first 595 at MOSI (MSB, for both sensor columns and LED columns)
 }

--- a/ls_sensor.ino
+++ b/ls_sensor.ino
@@ -121,11 +121,8 @@ inline unsigned short readZ() {                       // returns the raw Z value
 // spiAnalogRead:
 // returns raw ADC output at current cell
 inline short spiAnalogRead() {
-  byte msb = SPI.transfer(SPI_ADC, 0, SPI_CONTINUE);         // read byte MSB
-  byte lsb = SPI.transfer(SPI_ADC, 0);                       // read byte LSB
+  short raw = SPI.transfer16(SPI_ADC, 0);         // read 16-bit byte pair
 
-  short raw = short(msb) << 8;             // assemble the 2 transfered bytes into an int
-  raw |= lsb;
   return raw >> 2;                         // shift the 14-bit value from bits 16-2 to bits 14-0
 }
 


### PR DESCRIPTION
SPI communications are one of the unavoidable overheads in linnstrument code.  However, there's a lot of bookkeeping per transfer call added by the arduino library.  By adjusting the hardware SPI config we can reduce that bookkeeping by 50% by transferring twice as many bits on each call.

The three SPI calls all transfer data in multiples of 16-bits anyway, so they can all benefit.

Requires a small and un-scary patch to the arduino code to enable 16-bit and feed the extra 8 data bits through.

Full scan performance goes up by around 13%.

----
How/What

The SPI transfer hardware uses 32-bit registers TDR and RSR.   The top halfword is used for control data, but the bottom 16 bits are available to fill the shift register.  By default, only 8 of the bits are transferred.  Arduino library does not provide facility to configure for more bits.  But easily added.

So: copy the transfer function (now transfer16) and change the input/output type to 16-bit.  Also need to inform the SPI hardware that pin(X) likes to transfer data 16-bits at a time.  This is easy, other config constants are already passed through; one more.

Then carefully change the big block of code that says "BRICKS BE HERE".
----
Yes I bricked it once.  Turns out there's a pair of bytes in SPI_SENSOR which are called 'msb' and 'lsb'; but if you send msb in the msb, it all goes red screen of death.  The original code sent the msb last, so if that is followed there is no problem. 