### PR TITLE
Save 5% runtime by not waiting for super low values

### DIFF
--- a/ls_sensor.ino
+++ b/ls_sensor.ino
@@ -86,7 +86,11 @@ inline unsigned short readZ() {                       // returns the raw Z value
 
   short rawZ;
 
-  if (controlModeActive) {
+  rawZ = 4095 - spiAnalogRead();
+
+  if (rawZ < 10) {
+    // just proceed - a very low value rarely settles high
+  } else if (controlModeActive) {
     delayUsec(READZ_DELAY_CONTROLMODE);
 
     // read raw Z value and invert it from (4095 - 0) to (0-4095)


### PR DESCRIPTION
Context: Reducing full scan time can make room for experimenters to put more logic into control loop.  The current scan time is already great for musical use of this device.  
----
Based upon 10-20 high definition runs scanning Z at 1Mhz while switching sensor, observed that while low Z values around 35 sometimes settle high, values which are nearly 0 initially do not.

This patch samples Z immediately after switching sensor and if it's low (<10) will return immediately without waiting for settling.  This value could be reduced to (<2) and have nearly the same performance gain. 

Alone this reduces full scan by 5%. Combined with the SPI 16-bit patch the full scan now costs 3500ms (17% improvement) when nothing is pressed.

Testing notes: Briefly tested this patch and behaviour seems normal.  I will continue to observe for exceptions to this 'rule'.  

 