### PR TITLE
Add column offset global setting

### DIFF
--- a/linnstrument-firmware.ino
+++ b/linnstrument-firmware.ino
@@ -57,7 +57,7 @@ For any questions about this, contact Roger Linn Design at support@rogerlinndesi
 /******************************************** CONSTANTS ******************************************/
 
 const char* OSVersion = "203.";
-const char* OSVersionBuild = ".044";
+const char* OSVersionBuild = ".043";
 
 // SPI addresses
 #define SPI_LEDS    10               // Arduino pin for LED control over SPI

--- a/linnstrument-firmware.ino
+++ b/linnstrument-firmware.ino
@@ -57,7 +57,7 @@ For any questions about this, contact Roger Linn Design at support@rogerlinndesi
 /******************************************** CONSTANTS ******************************************/
 
 const char* OSVersion = "203.";
-const char* OSVersionBuild = ".043";
+const char* OSVersionBuild = ".044";
 
 // SPI addresses
 #define SPI_LEDS    10               // Arduino pin for LED control over SPI
@@ -691,6 +691,7 @@ struct GlobalSettings {
   int accentNotes[12];                       // bitmask array that determines which notes receive accent lights (octaves, white keys, black keys, etc.)
   byte rowOffset;                            // interval between rows. 0 = no overlap, 1-12 = interval, 13 = guitar
   signed char customRowOffset;               // the custom row offset that can be configured at the location of the octave setting
+  signed char colOffset;                     // semitones between columns.  default 1.
   VelocitySensitivity velocitySensitivity;   // See VelocitySensitivity values
   unsigned short minForVelocity;             // 1-127
   unsigned short maxForVelocity;             // 1-127

--- a/ls_displayModes.ino
+++ b/ls_displayModes.ino
@@ -1403,6 +1403,9 @@ void paintGlobalSettingsDisplay() {
       case 3:
         lightLed(19, 2);
         break;
+      case 4:
+        lightLed(19, 3);
+        break;
     }
 
     // This code assumes that switchSelect values are the same as the row numbers

--- a/ls_displayModes.ino
+++ b/ls_displayModes.ino
@@ -1393,6 +1393,18 @@ void paintGlobalSettingsDisplay() {
         break;
     }
 
+    switch (Global.colOffset) {
+      case 1:
+        lightLed(19, 0);
+        break;
+      case 2:
+        lightLed(19, 1);
+        break;
+      case 3:
+        lightLed(19, 2);
+        break;
+    }
+
     // This code assumes that switchSelect values are the same as the row numbers
     lightLed(7, switchSelect);
     paintSwitchAssignment(Global.switchAssignment[switchSelect]);

--- a/ls_handleTouches.ino
+++ b/ls_handleTouches.ino
@@ -1380,6 +1380,11 @@ short handleXExpression() {
     }
   }
 
+  // apply column offset to pitch bend
+  if (result != INVALID_DATA) {
+      result = result * Global.colOffset;
+  }
+
   return result;
 }
 
@@ -1817,6 +1822,9 @@ byte getNoteNumber(byte split, byte col, byte row) {
   if (Device.leftHanded) {
     noteCol = (NUMCOLS - col);
   }
+
+  // apply column offset
+  noteCol *= Global.colOffset;
 
   notenum = lowest + (row * offset) + noteCol - 1;
 

--- a/ls_midi.ino
+++ b/ls_midi.ino
@@ -1163,6 +1163,11 @@ short getNoteNumColumn(byte split, byte notenum, byte row) {
 
   short col = notenum - (lowest + (row * offset) + Split[split].transposeOctave) + 1   // calculate the column that this MIDI note can be played on
             + Split[split].transposeLights - Split[split].transposePitch;;             // adapt for transposition settings
+
+  // apply column offset
+  if (col % Global.colOffset != 0) { return -1; }                                      // when col offset is not 1, rows can skip notes
+  col /= Global.colOffset;
+
   if (Device.leftHanded) {
     col = NUMCOLS - col;
   }
@@ -1172,6 +1177,7 @@ short getNoteNumColumn(byte split, byte notenum, byte row) {
   if (col < lowColSplit || col >= highColSplit) {                                      // only return columns that are valid for the split
     col = -1;
   }
+
 
   return col;
 }

--- a/ls_midi.ino
+++ b/ls_midi.ino
@@ -1178,7 +1178,6 @@ short getNoteNumColumn(byte split, byte notenum, byte row) {
     col = -1;
   }
 
-
   return col;
 }
 

--- a/ls_settings.ino
+++ b/ls_settings.ino
@@ -440,6 +440,7 @@ void initializePresetSettings() {
 
     g.rowOffset = 5;
     g.customRowOffset = 12;
+    g.colOffset = 1;
     g.velocitySensitivity = velocityMedium;
     g.minForVelocity = DEFAULT_MIN_VELOCITY;
     g.maxForVelocity = DEFAULT_MAX_VELOCITY;
@@ -2369,6 +2370,20 @@ void handleGlobalSettingNewTouch() {
             else {
               Global.rowOffset = ROWOFFSET_NOOVERLAP;
             }
+            break;
+        }
+        break;
+
+      case 19:
+        switch (sensorRow) {
+          case 0:
+            Global.colOffset = 1;
+            break;
+          case 1:
+            Global.colOffset = 2;
+            break;
+          case 2:
+            Global.colOffset = 3;
             break;
         }
         break;

--- a/ls_settings.ino
+++ b/ls_settings.ino
@@ -2385,6 +2385,9 @@ void handleGlobalSettingNewTouch() {
           case 2:
             Global.colOffset = 3;
             break;
+          case 3:
+            Global.colOffset = 4;
+            break;
         }
         break;
 


### PR DESCRIPTION
Adds a global setting to change column offset (number of semitones between horizontally adjacent buttons).

The setting is on column 19 of the global settings panel.  The values from bottom to top are 1, 2, 3, 4.  The default value 1 is identical to normal Linnstrument behavior.

Now you can play these kinds of isomorphic keyboard layouts:

* Row +1, Column +2: [Janko keyboard](https://en.wikipedia.org/wiki/Jankó_keyboard), but square instead of hex
* Row +1, Column +3: [Minor Thirds](https://itunes.apple.com/us/app/minorthirds/id1018314889?mt=8)
* Row +5, Column +2: [Wicki-Hayden](https://en.wikipedia.org/wiki/Wicki-Hayden_note_layout), used on concertinas and ["jammer"](https://en.wikipedia.org/wiki/Jammer_keyboard) midi instruments... but square instead of hex

(Like in the stock firmware, to get Row+1 you can hold down the "octave" row offset button to enter a custom number.)

This works with:
* octave, pitch, and transpose settings
* split keyboards
* left-handed keyboard setting
* pitch bending, with or without quantization.  (The spacing along a row is still uniform, so sliding works like you expect, but faster)

To do:
* Can't set this setting through MIDI yet
* The pitch bend quantization-hold behavior is slightly weird because it still snaps to the nearest semitone.  To guarantee you end on the note you want you have to end your slide on the left side of a button instead of the center.  I wasn't able to figure out how to change the quantization-hold granularity to go in jumps of N semitones.

This was inspired by [ja-self's pull request](https://github.com/rogerlinndesign/linnstrument-firmware/pull/11) which had this feature along with a bunch of other stuff, but I wrote it myself.