### PR TITLE
Fix for arpeggiator release bug.

### DIFF
--- a/linnstrument-firmware.ino
+++ b/linnstrument-firmware.ino
@@ -426,6 +426,11 @@ struct NoteTouchMapping {
   boolean hasTouch(signed char, signed char);                // indicates whether there's a touch active for a particular note and channel
   inline NoteEntry* getNoteEntry(signed char, signed char);  // get the entry for a particular note and channel
   inline byte getMusicalTouchCount(signed char);             // the number of musical touches for a particular MIDI channel
+  inline boolean isAnyNotePressed();                         // true if any note is actively being pressed, accounts for stale notes that are being deferred
+  void clearStaleNote();                                     // clear the stale note, resetting it for next use
+  void setStaleNote(signed char, signed char);               // set the stale note to the designated note/channel
+  inline boolean isNoteStale(signed char, signed char);      // true if the passed in note/channel are the stale note last set
+  inline boolean hasStaleNote();                             // true if there is a valid stale note set
 
   void debugNoteChain();
 
@@ -435,6 +440,13 @@ struct NoteTouchMapping {
   signed char firstChannel;
   signed char lastNote;
   signed char lastChannel;
+
+  // When using the arp, a stale note is a note that gets released while the arp is actively playing the note. For these notes, we want to keep them in the
+  // mapping until the arp has finished playing them. Once the arp sequence turns the stale note off, it is no longer needed. It's phsyically impossible
+  // to ever have more than 1 stale note at a time on a single split.
+  signed char staleNote;
+  signed char staleChannel;
+
   NoteEntry mapping[128][16];
 };
 NoteTouchMapping noteTouchMapping[NUMSPLITS];

--- a/ls_handleTouches.ino
+++ b/ls_handleTouches.ino
@@ -1732,18 +1732,23 @@ void handleTouchRelease() {
       preSendLoudness(sensorSplit, 0, 0, sensorCell->note, sensorCell->channel);
     }
 
-    // unregister the note <> cell mapping
-    if (!isSwitchLegatoPressed(sensorSplit) && (!isArpeggiatorEnabled(sensorSplit) || !isSwitchLatchPressed(sensorSplit))) {
-      noteTouchMapping[sensorSplit].noteOff(sensorCell->note, sensorCell->channel);
-    }
-
+    // See if we should unregister the note <> cell mapping
+    boolean shouldUnregisterNote = !isSwitchLegatoPressed(sensorSplit) && (!isArpeggiatorEnabled(sensorSplit) || !isSwitchLatchPressed(sensorSplit));
+    
     // send the Note Off
     if (isArpeggiatorEnabled(sensorSplit)) {
       if (!isSwitchLatchPressed(sensorSplit)) {
         handleArpeggiatorNoteOff(sensorSplit, sensorCell->note, sensorCell->channel);
       }
+      else if(shouldUnregisterNote) {
+        noteTouchMapping[sensorSplit].noteOff(sensorCell->note, sensorCell->channel);
+      }
     }
     else {
+      if(shouldUnregisterNote) {
+        noteTouchMapping[sensorSplit].noteOff(sensorCell->note, sensorCell->channel);
+      }
+      
       if (isStrummedSplit(sensorSplit)) {
         handleStrummedRowChange(false, sensorCell->velocity);
       }


### PR DESCRIPTION
When the arpeggiator is enabled and the active note is released, the arpeggiator pattern resets. This is described in detail in this thread:
https://www.kvraudio.com/forum/viewtopic.php?f=263&t=535623

Repro steps are:

1. Turn Arpeggiator on and set it to very slowly arpeggiate through a chord so it’s
easy to hear the problem. .
2. Hold a 4-note chord.
3. Immediately AFTER the second or third note in the arpeggio plays, release that
note.
4. Notice that a) the released note terminates immediately instead of sustaining
until the next note in the arpeggio, and b the arpeggio immediately resets to the
lowest note of the chord. It should continue to the next note in the chord. Notice
that this only occurs if you release your finger immediately AFTER its note plays
in the arpeggio and not if you release it immediately BEFORE it plays.

This PR resolves this issue by introducing the concept of a **stale note**. Before, if the active note in the arp sequence was released, the midi would be turned off and the arp sequence would be reset. Now, when the active note in the arp sequence is released, that note is marked as stale but the note remains in the cell mapping and the midi stays on.

Later on in `advanceArpeggiatorForSplit`, when the next note in the arp sequence is determined, we check to see if the previous note in the sequence is stale and remove it from the cell mapping at that time.

The variables I added to `NoteTouchMapping` increased its size by 2 bytes. Average free memory sits around 11,664 bytes, again about a 2 byte delta.