### PR TITLE
Fix wraparound bug for tempo display in Global Settings.

### DIFF
--- a/ls_displayModes.ino
+++ b/ls_displayModes.ino
@@ -1768,7 +1768,7 @@ void paintGlobalSettingsDisplay() {
     byte color = Split[LEFT].colorMain;
     char str[4];
     const char* format = "%3d";
-    snprintf(str, sizeof(str), format, (byte)FXD4_TO_INT(fxd4CurrentTempo));
+    snprintf(str, sizeof(str), format, FXD4_TO_INT(fxd4CurrentTempo));
     tinyfont_draw_string(0, 4, str, color);
   }
 


### PR DESCRIPTION
This cast resulted in the display going from 1 to 255, then wrapping around to 0, and going up to 104. (These values just reflect the fact that `fxd4CurrentTempo` is constrained to 1..360.)